### PR TITLE
Updates Yamcs docker version to fix errors

### DIFF
--- a/simulator/Dockerfile
+++ b/simulator/Dockerfile
@@ -1,6 +1,4 @@
 FROM python:3.11
 WORkDIR /simulator
 RUN git clone https://github.com/yamcs/quickstart.git
-RUN cd quickstart && sed -i "/tm_socket.sendto/s,'127.0.0.1','yamcs',g" simulator.py && \
-    sed -i "s/sleep(1)/sleep(0.3)/g" simulator.py
-CMD cd quickstart && python simulator.py
+CMD cd quickstart && python simulator.py --tm_host yamcs

--- a/yamcs/Dockerfile
+++ b/yamcs/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.5-openjdk-17
+FROM maven:3.9.9-eclipse-temurin-17 
 
 WORKDIR /yamcs
 
@@ -11,7 +11,7 @@ RUN sed -i '/<\/dependencies>/i \
     <dependency>\
       <groupId>org.yamcs</groupId>\
       <artifactId>yamcs-prometheus</artifactId>\
-      <version>1.2.0</version>\
+      <version>1.3.0</version>\
     </dependency>' /yamcs/quickstart/pom.xml
 
 # Compile the project


### PR DESCRIPTION
Fixes https://github.com/scottbell/openmct-quickstart/issues/7

Code rot in the Yamcs docker image caused Docker runtime errors. This updates the version of the Yamcs image used by openmct-quickstart.

The command to initiate example playback data in Yamcs was also invalidated by a code change in yamcs-quickstart.